### PR TITLE
fix: console errors instead of logs on status messages

### DIFF
--- a/src/mcp-service.ts
+++ b/src/mcp-service.ts
@@ -21,7 +21,7 @@ class SwarmMCPServer {
   private bee: Bee;
 
   constructor() {
-    console.log('[Setup] Initializing Swarm MCP server...');
+    console.error('[Setup] Initializing Swarm MCP server...');
 
     // Initialize Bee client with the configured endpoint
     this.bee = new Bee(config.bee.endpoint);
@@ -204,7 +204,7 @@ class SwarmMCPServer {
   async run() {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    console.log('Swarm MCP server running on stdio');
+    console.error('Swarm MCP server running on stdio');
   }
 }
 

--- a/src/tools/download-folder.ts
+++ b/src/tools/download-folder.ts
@@ -29,7 +29,7 @@ export async function downloadFolder(args: DownloadFolderArgs, bee: Bee, transpo
     );
   }
 
-  console.log(`[API] Downloading folder from Swarm with reference: ${args.reference}`);
+  console.error(`[API] Downloading folder from Swarm with reference: ${args.reference}`);
 
   // Check if the reference is a manifest
   let isManifest = false;

--- a/src/tools/download-text.ts
+++ b/src/tools/download-text.ts
@@ -26,7 +26,7 @@ export async function downloadText(args: DownloadTextArgs, bee: Bee): Promise<To
   const refNotSwarmHash = args.reference.length !== 64 && args.reference.length !== 66
   let textData: string;
   if (args.isMemoryTopic || refNotSwarmHash) {
-    console.log(`[API] Downloading text from Swarm feed with topic: ${args.reference}`);
+    console.error(`[API] Downloading text from Swarm feed with topic: ${args.reference}`);
     
     if (!config.bee.feedPrivateKey) {
       throw new McpError(
@@ -76,9 +76,9 @@ export async function downloadText(args: DownloadTextArgs, bee: Bee): Promise<To
     // Download the referenced data
     textData = latestUpdate.payload.toUtf8();
 
-    console.log(`[API] Successfully downloaded feed content with topic: ${args.reference}`);
+    console.error(`[API] Successfully downloaded feed content with topic: ${args.reference}`);
   } else {
-    console.log(`[API] Downloading text from Swarm with reference: ${args.reference}`);
+    console.error(`[API] Downloading text from Swarm with reference: ${args.reference}`);
     const data = await bee.downloadData(args.reference);
     textData = data.toUtf8();
   }


### PR DESCRIPTION
fixing error from Claude Desktop:

```
"[Setup] Ini"... is not valid JSON {
  metadata: {
    context: 'connection',
    stack: SyntaxError: Unexpected token 'S', "[Setup] Ini"... is not valid JSON\n +
```